### PR TITLE
🐛 fix(auth): support anonymous Jenkins instances and fix crumb cookie handling

### DIFF
--- a/src/common/env.ts
+++ b/src/common/env.ts
@@ -3,6 +3,7 @@ export interface JenkinsEnv {
   JENKINS_USER?: string
   JENKINS_API_TOKEN?: string
   JENKINS_BEARER_TOKEN?: string
+  JENKINS_ANONYMOUS?: boolean
 }
 
 export interface CliArgs {
@@ -10,6 +11,7 @@ export interface CliArgs {
   jenkinsUser?: string
   jenkinsApiToken?: string
   jenkinsBearerToken?: string
+  jenkinsAnonymous?: boolean
 }
 
 // Store resolved configs globally to avoid re-parsing
@@ -36,11 +38,12 @@ const buildInstanceEnv = (
   user: string | undefined,
   apiToken: string | undefined,
   bearerToken: string | undefined,
+  anonymous: boolean,
 ): JenkinsEnv => {
   const hasBasicAuth = user && apiToken
   const hasBearerAuth = bearerToken
 
-  if (!hasBasicAuth && !hasBearerAuth) {
+  if (!hasBasicAuth && !hasBearerAuth && !anonymous) {
     throw new Error(
       `Missing Jenkins authentication for URL ${url}. Provide via:\n` +
         "  Bearer Token:\n" +
@@ -48,7 +51,10 @@ const buildInstanceEnv = (
         "    2. Environment: MCP_JENKINS_BEARER_TOKEN=<token>\n" +
         "  OR Basic Auth:\n" +
         "    1. CLI: --user <user> --api-token <token>\n" +
-        "    2. Environment: MCP_JENKINS_USER=<user> MCP_JENKINS_API_TOKEN=<token>",
+        "    2. Environment: MCP_JENKINS_USER=<user> MCP_JENKINS_API_TOKEN=<token>\n" +
+        "  OR Anonymous (no-auth Jenkins instance):\n" +
+        "    1. CLI: --anonymous\n" +
+        "    2. Environment: MCP_JENKINS_ANONYMOUS=true",
     )
   }
 
@@ -57,6 +63,7 @@ const buildInstanceEnv = (
     JENKINS_USER: user || undefined,
     JENKINS_API_TOKEN: apiToken || undefined,
     JENKINS_BEARER_TOKEN: bearerToken || undefined,
+    JENKINS_ANONYMOUS: anonymous || undefined,
   }
 }
 
@@ -91,6 +98,12 @@ export const loadAllJenkinsInstances = (
     cliArgs?.jenkinsBearerToken,
     "MCP_JENKINS_BEARER_TOKEN",
   )
+  const rawAnonymous = getConfigValue(
+    cliArgs?.jenkinsAnonymous !== undefined
+      ? String(cliArgs.jenkinsAnonymous)
+      : undefined,
+    "MCP_JENKINS_ANONYMOUS",
+  )
   const rawInstances = process.env["MCP_JENKINS_INSTANCES"]
 
   if (!rawUrl) {
@@ -105,6 +118,7 @@ export const loadAllJenkinsInstances = (
   const users = splitValues(rawUser)
   const apiTokens = splitValues(rawApiToken)
   const bearerTokens = splitValues(rawBearerToken)
+  const anonymousFlags = splitValues(rawAnonymous)
   const instanceNames = rawInstances
     ? splitValues(rawInstances)
     : urls.map((url) => new URL(url).hostname.split(".")[0])
@@ -123,7 +137,13 @@ export const loadAllJenkinsInstances = (
     const user = users[i] ?? users[0]
     const apiToken = apiTokens[i] ?? apiTokens[0]
     const bearerToken = bearerTokens[i] ?? bearerTokens[0]
-    instances.set(name, buildInstanceEnv(url, user, apiToken, bearerToken))
+    const anonymous =
+      ((anonymousFlags[i] ?? anonymousFlags[0]) || "false").toLowerCase() ===
+      "true"
+    instances.set(
+      name,
+      buildInstanceEnv(url, user, apiToken, bearerToken, anonymous),
+    )
   }
 
   if (cliArgs) cachedInstances = instances

--- a/src/index.ts
+++ b/src/index.ts
@@ -731,6 +731,9 @@ const parseCliArgs = (): CliArgs => {
           i++
         }
         break
+      case "--anonymous":
+        args.jenkinsAnonymous = true
+        break
       case "--help":
       case "-h":
         console.log(`
@@ -747,10 +750,12 @@ Options:
   --user <username>      Jenkins username (for Basic auth)
   --api-token <token>    Jenkins API token (for Basic auth)
   --bearer-token <token> Jenkins bearer token (OAuth/token auth)
+  --anonymous            No-auth Jenkins instance (no credentials required)
   -h, --help             Show this help message
 
 Authentication:
   Either provide --bearer-token OR both --user and --api-token
+  OR use --anonymous for Jenkins instances with no authentication
 
 Tool Filtering (via environment variables):
   MCP_JENKINS_ALLOW_TOOLS=<tool1>,<tool2>  Allowlist — expose only these tools

--- a/src/index.ts
+++ b/src/index.ts
@@ -814,12 +814,14 @@ let defaultInstance: string
 try {
   const instances = loadAllJenkinsInstances(cliArgs)
   for (const [name, env] of instances) {
-    const authHeader = env.JENKINS_BEARER_TOKEN
-      ? "Bearer " + env.JENKINS_BEARER_TOKEN
-      : "Basic " +
-        Buffer.from(`${env.JENKINS_USER}:${env.JENKINS_API_TOKEN}`).toString(
-          "base64",
-        )
+    const authHeader = env.JENKINS_ANONYMOUS
+      ? undefined
+      : env.JENKINS_BEARER_TOKEN
+        ? "Bearer " + env.JENKINS_BEARER_TOKEN
+        : "Basic " +
+          Buffer.from(`${env.JENKINS_USER}:${env.JENKINS_API_TOKEN}`).toString(
+            "base64",
+          )
     clients.set(
       name,
       new JenkinsClient({ baseUrl: env.JENKINS_URL, authHeader }),
@@ -827,7 +829,11 @@ try {
     logger.info("Jenkins client initialized", {
       instance: name,
       url: env.JENKINS_URL,
-      authType: env.JENKINS_BEARER_TOKEN ? "bearer" : "basic",
+      authType: env.JENKINS_ANONYMOUS
+        ? "anonymous"
+        : env.JENKINS_BEARER_TOKEN
+          ? "bearer"
+          : "basic",
     })
   }
   defaultInstance = instances.keys().next().value as string

--- a/src/lib/jenkins-client.ts
+++ b/src/lib/jenkins-client.ts
@@ -21,7 +21,7 @@ export interface NormalizedBuild {
 
 export interface JenkinsCredentials {
   baseUrl: string
-  authHeader: string
+  authHeader?: string
 }
 
 interface CrumbInfo {

--- a/src/lib/jenkins-client.ts
+++ b/src/lib/jenkins-client.ts
@@ -31,24 +31,23 @@ interface CrumbInfo {
 
 export class JenkinsClient {
   readonly baseUrl: string
-  private authHeader: string
+  private authHeader: string | undefined
   private crumb?: CrumbInfo
+  private cookies: string | undefined
 
   constructor(credentials?: JenkinsCredentials) {
     if (credentials) {
-      // Use credentials provided by the caller (from request headers)
       this.baseUrl = credentials.baseUrl
       this.authHeader = credentials.authHeader
     } else {
-      // loadJenkinsEnv will use globally set values from CLI args or env vars
       const env = loadJenkinsEnv()
       this.baseUrl = env.JENKINS_URL
 
-      // Support both Bearer token and Basic auth from env
-      if (env.JENKINS_BEARER_TOKEN) {
+      if (env.JENKINS_ANONYMOUS) {
+        this.authHeader = undefined
+      } else if (env.JENKINS_BEARER_TOKEN) {
         this.authHeader = "Bearer " + env.JENKINS_BEARER_TOKEN
       } else {
-        // Fall back to Basic auth with user + API token
         this.authHeader =
           "Basic " +
           Buffer.from(env.JENKINS_USER + ":" + env.JENKINS_API_TOKEN).toString(
@@ -58,8 +57,11 @@ export class JenkinsClient {
     }
   }
 
-  private headers(extra?: Record<string, string>) {
-    return { Authorization: this.authHeader, ...extra }
+  private headers(extra?: Record<string, string>): Record<string, string> {
+    const h: Record<string, string> = {}
+    if (this.authHeader) h["Authorization"] = this.authHeader
+    if (this.cookies) h["Cookie"] = this.cookies
+    return { ...h, ...extra }
   }
 
   // List jobs (shallow) returns name + url
@@ -175,14 +177,32 @@ export class JenkinsClient {
   private async ensureCrumb(): Promise<CrumbInfo | undefined> {
     if (this.crumb) return this.crumb
     try {
-      const crumb = await httpGetJson<CrumbInfo>(
-        `${this.baseUrl}/crumbIssuer/api/json`,
-        { headers: this.headers() },
-      )
+      const controller = new AbortController()
+      const t = setTimeout(() => controller.abort(), 10000)
+      let res: Response
+      try {
+        res = await fetch(`${this.baseUrl}/crumbIssuer/api/json`, {
+          headers: this.headers(),
+          signal: controller.signal,
+        })
+      } finally {
+        clearTimeout(t)
+      }
+      if (!res.ok) {
+        logger.warn("Crumb fetch failed (continuing)", { status: res.status })
+        return undefined
+      }
+      const setCookies: string[] =
+        typeof (res.headers as any).getSetCookie === "function"
+          ? (res.headers as any).getSetCookie()
+          : ([res.headers.get("set-cookie")].filter(Boolean) as string[])
+      if (setCookies.length > 0) {
+        this.cookies = setCookies.map((c) => c.split(";")[0].trim()).join("; ")
+      }
+      const crumb = (await res.json()) as CrumbInfo
       this.crumb = crumb
       return crumb
     } catch (e: any) {
-      // Some Jenkins instances may not have CSRF protection enabled
       logger.warn("Crumb fetch failed (continuing)", { error: String(e) })
       return undefined
     }

--- a/test/common/env.test.ts
+++ b/test/common/env.test.ts
@@ -79,6 +79,7 @@ describe("loadAllJenkinsInstances — 2-tier priority", () => {
     delete process.env["MCP_JENKINS_USER"]
     delete process.env["MCP_JENKINS_API_TOKEN"]
     delete process.env["MCP_JENKINS_BEARER_TOKEN"]
+    delete process.env["MCP_JENKINS_ANONYMOUS"]
     delete process.env["MCP_JENKINS_INSTANCES"]
     delete process.env["JENKINS_URL"]
     delete process.env["JENKINS_USER"]
@@ -199,5 +200,37 @@ describe("loadAllJenkinsInstances — 2-tier priority", () => {
     process.env["MCP_JENKINS_API_TOKEN"] = "token"
 
     expect(() => loadAllJenkinsInstances({})).toThrow("counts must match")
+  })
+
+  it("anonymous single-instance accepts no user or token", () => {
+    process.env["MCP_JENKINS_URL"] = "https://jenkins.example.com"
+    process.env["MCP_JENKINS_ANONYMOUS"] = "true"
+
+    const instances = loadAllJenkinsInstances({})
+    const env = instances.values().next().value
+    expect(env.JENKINS_ANONYMOUS).toBe(true)
+    expect(env.JENKINS_USER).toBeUndefined()
+    expect(env.JENKINS_API_TOKEN).toBeUndefined()
+  })
+
+  it("multi-instance positional anonymous flags apply per-instance", () => {
+    process.env["MCP_JENKINS_URL"] =
+      "https://pipeline.example.com,https://scheduler.example.com"
+    process.env["MCP_JENKINS_ANONYMOUS"] = "true,false"
+    process.env["MCP_JENKINS_USER"] = ",admin"
+    process.env["MCP_JENKINS_API_TOKEN"] = ",token2"
+
+    const instances = loadAllJenkinsInstances({})
+    expect(instances.get("pipeline")!.JENKINS_ANONYMOUS).toBe(true)
+    expect(instances.get("scheduler")!.JENKINS_ANONYMOUS).toBeUndefined()
+  })
+
+  it("cliArgs.jenkinsAnonymous takes precedence over MCP_JENKINS_ANONYMOUS env var", () => {
+    process.env["MCP_JENKINS_URL"] = "https://jenkins.example.com"
+    process.env["MCP_JENKINS_ANONYMOUS"] = "false"
+
+    const instances = loadAllJenkinsInstances({ jenkinsAnonymous: true })
+    const env = instances.values().next().value
+    expect(env.JENKINS_ANONYMOUS).toBe(true)
   })
 })

--- a/test/lib/jenkins-client.test.ts
+++ b/test/lib/jenkins-client.test.ts
@@ -1,6 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { JenkinsClient } from "../../src/lib/jenkins-client.js"
 import * as common from "../../src/common/index.js"
+
+const mockFetchResponse = (body: unknown, setCookie?: string) =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    headers: {
+      get: (h: string) => (h === "set-cookie" ? (setCookie ?? null) : null),
+      getSetCookie: () => (setCookie ? [setCookie] : []),
+    },
+    json: () => Promise.resolve(body),
+  } as unknown as Response)
 
 vi.mock("../../src/common/index.js", () => {
   class McpError extends Error {
@@ -38,7 +49,12 @@ describe("JenkinsClient", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubGlobal("fetch", vi.fn())
     client = new JenkinsClient()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   describe("constructor", () => {
@@ -241,7 +257,7 @@ describe("JenkinsClient", () => {
   describe("triggerBuild", () => {
     it("should trigger build without parameters", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "abc123" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({
         headers: { location: "https://jenkins.example.com/queue/item/123/" },
       })
@@ -264,7 +280,7 @@ describe("JenkinsClient", () => {
 
     it("should trigger build with parameters", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "xyz789" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({
         headers: { location: "https://jenkins.example.com/queue/item/456/" },
       })
@@ -281,6 +297,31 @@ describe("JenkinsClient", () => {
             "Content-Type": "application/x-www-form-urlencoded",
           }),
           body: expect.stringContaining("branch=main"),
+        }),
+      )
+    })
+
+    it("captures Set-Cookie from crumb fetch and injects Cookie on POST", async () => {
+      const mockCrumb = {
+        crumbRequestField: "Jenkins-Crumb",
+        crumb: "cookie123",
+      }
+      vi.mocked(fetch).mockReturnValue(
+        mockFetchResponse(mockCrumb, "JSESSIONID=abc123; Path=/"),
+      )
+      vi.mocked(common.httpPost).mockResolvedValue({
+        status: 201,
+        headers: { location: "/queue/1" },
+      })
+
+      await client.triggerBuild("my-job")
+
+      expect(common.httpPost).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Cookie: "JSESSIONID=abc123",
+          }),
         }),
       )
     })
@@ -348,7 +389,7 @@ describe("JenkinsClient", () => {
   describe("stopBuild", () => {
     it("should stop a running build", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "stop123" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ headers: {} })
 
       const result = await client.stopBuild("my-job", 50)
@@ -444,7 +485,7 @@ describe("JenkinsClient", () => {
   describe("createJob", () => {
     it("should create a job with XML config", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "crumb1" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ status: 200, headers: {} })
 
       const result = await client.createJob("new-job", "<project/>")
@@ -463,7 +504,7 @@ describe("JenkinsClient", () => {
 
     it("should throw on HTTP 4xx response", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "crumb1" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ status: 400, headers: {} })
 
       await expect(client.createJob("bad-job", "<bad/>")).rejects.toThrow(
@@ -475,7 +516,7 @@ describe("JenkinsClient", () => {
   describe("updateJobConfig", () => {
     it("should update job config", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "crumb2" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ status: 200, headers: {} })
 
       const result = await client.updateJobConfig("my-job", "<project/>")
@@ -491,7 +532,7 @@ describe("JenkinsClient", () => {
   describe("renameJob", () => {
     it("should rename a job", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "crumb3" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ status: 200, headers: {} })
 
       const result = await client.renameJob("old-name", "new-name")
@@ -511,7 +552,7 @@ describe("JenkinsClient", () => {
   describe("copyJob", () => {
     it("should copy a job", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "crumb4" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ status: 200, headers: {} })
 
       const result = await client.copyJob("source-job", "copy-job")
@@ -561,7 +602,7 @@ describe("JenkinsClient", () => {
   describe("toggleNodeOffline", () => {
     it("should toggle node offline", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "crumb5" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ status: 200, headers: {} })
 
       const result = await client.toggleNodeOffline("agent-1", "maintenance")
@@ -633,7 +674,7 @@ describe("JenkinsClient", () => {
   describe("quietDown", () => {
     it("should enable quiet mode", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "crumb6" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ status: 200, headers: {} })
 
       const result = await client.quietDown("scheduled maintenance")
@@ -649,7 +690,7 @@ describe("JenkinsClient", () => {
   describe("cancelQuietDown", () => {
     it("should cancel quiet mode", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "crumb7" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ status: 200, headers: {} })
 
       const result = await client.cancelQuietDown()
@@ -665,7 +706,7 @@ describe("JenkinsClient", () => {
   describe("safeRestart", () => {
     it("should initiate safe restart", async () => {
       const mockCrumb = { crumbRequestField: "Jenkins-Crumb", crumb: "crumb8" }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ status: 200, headers: {} })
 
       const result = await client.safeRestart()
@@ -684,7 +725,7 @@ describe("JenkinsClient", () => {
         crumbRequestField: "Jenkins-Crumb",
         crumb: "replay123",
       }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({
         headers: { location: "https://jenkins.example.com/queue/item/77/" },
       })
@@ -710,7 +751,7 @@ describe("JenkinsClient", () => {
         crumbRequestField: "Jenkins-Crumb",
         crumb: "replay456",
       }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({
         headers: { location: "https://jenkins.example.com/queue/item/88/" },
       })
@@ -744,7 +785,7 @@ describe("JenkinsClient", () => {
         crumbRequestField: "Jenkins-Crumb",
         crumb: "replaynoloc",
       }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ headers: {} })
 
       const result = await client.replayBuild("my-pipeline", 3)
@@ -757,7 +798,7 @@ describe("JenkinsClient", () => {
         crumbRequestField: "Jenkins-Crumb",
         crumb: "replay404",
       }
-      vi.mocked(common.httpGetJson).mockResolvedValue(mockCrumb)
+      vi.mocked(fetch).mockReturnValue(mockFetchResponse(mockCrumb))
       vi.mocked(common.httpPost).mockResolvedValue({ status: 404, headers: {} })
 
       await expect(client.replayBuild("missing-pipeline", 1)).rejects.toThrow(


### PR DESCRIPTION
## 🎟️ Ticket

**Ticket:** Closes #7 — "Anonymous (no-auth) Jenkins instances not supported & No valid crumb was included in the request"

### 📄 Description

Fixes two related bugs that prevented mcp-jenkins from working with Jenkins instances that have authentication disabled.

**Bug 1 — Anonymous mode flag (`src/common/env.ts`)**

The startup check that enforced auth credentials would throw immediately when no credentials were provided, even for public/anonymous Jenkins instances. A new `JENKINS_ANONYMOUS` flag (`--anonymous` CLI flag / `MCP_JENKINS_ANONYMOUS=true` env var) bypasses this check. It is fully multi-instance aware — each instance in a comma-separated `MCP_JENKINS_URL` list can be toggled individually.

**Bug 2 — Crumb + session cookie (`src/lib/jenkins-client.ts`)**

`ensureCrumb()` previously used the shared `httpGetJson` helper, which discards response headers. On anonymous Jenkins instances with CSRF enabled, the crumb is tied to a session cookie issued by the `/crumbIssuer` endpoint. Without that cookie, every subsequent mutating request returned `403 No valid crumb was included in the request`.

The fix switches `ensureCrumb()` to a raw `fetch()` call so it can read `Set-Cookie` response headers. The cookies are stored on the `JenkinsClient` instance and injected into all subsequent requests via `headers()`. The `Authorization` header is now conditionally omitted when anonymous mode is active.

**Bug 3 — CLI wiring (`src/index.ts`)**

Added the `--anonymous` flag to the CLI argument parser and help text, wired to `CliArgs.jenkinsAnonymous`.

### 📽️ Screencast

No visual changes.

### ✅ How to Validate

1. Stand up a Jenkins instance with security disabled (or use one with "Allow anonymous read access").
2. Run the server without credentials:
   ```
   npx mcp-jenkins --url http://localhost:8080 --anonymous
   ```
   or with the env var:
   ```
   MCP_JENKINS_URL=http://localhost:8080 MCP_JENKINS_ANONYMOUS=true npx mcp-jenkins
   ```
3. Confirm no startup auth error is thrown.
4. Issue a mutating tool call (e.g. trigger a build). Confirm it succeeds without a `403 No valid crumb` error.
5. Confirm authenticated instances (bearer / basic) continue to work unchanged.

### 🛠️ Developer Checklist

- [x] Code is readable and maintainable
- [x] Tests included and passing (if applicable)
- [x] PR is atomic and focused on a single feature or bug
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)

