### PR TITLE
fix(jenkins-client): validate jobName and tolerate URL-style paths in jobPath

### DIFF
--- a/src/lib/jenkins-client.ts
+++ b/src/lib/jenkins-client.ts
@@ -8,8 +8,23 @@ import {
   loadJenkinsEnv,
 } from "../common/index.js"
 
-const jobPath = (name: string): string =>
-  name.split("/").map(encodeURIComponent).join("/job/")
+const jobPath = (name: string): string => {
+  if (typeof name !== "string" || name.trim() === "") {
+    throw new McpError(
+      "INVALID_INPUT",
+      "jobName is required and must be a non-empty string. Use folder/sub/job for nested jobs; the /job/ separators, a leading slash, and the full URL are all tolerated.",
+      400,
+    )
+  }
+  // Accept plain nested names (a/b), URL-style paths that already contain the
+  // /job/ separators (a/job/b), and stray leading/trailing slashes — all of
+  // which should resolve to the same Jenkins path segments.
+  return name
+    .split("/")
+    .filter((segment) => segment.length > 0 && segment !== "job")
+    .map(encodeURIComponent)
+    .join("/job/")
+}
 
 export interface NormalizedBuild {
   id: string

--- a/test/lib/jenkins-client.test.ts
+++ b/test/lib/jenkins-client.test.ts
@@ -719,6 +719,55 @@ describe("JenkinsClient", () => {
     })
   })
 
+  describe("jobPath (nested folders, URL-style paths, validation)", () => {
+    const mockBuild = { number: 7, building: false }
+
+    it("resolves a plain nested folder name to /job/ segments", async () => {
+      vi.mocked(common.httpGetJson).mockResolvedValue(mockBuild)
+
+      await client.getBuild("folder/sub/my-job", 7)
+
+      expect(common.httpGetJson).toHaveBeenCalledWith(
+        "https://jenkins.example.com/job/folder/job/sub/job/my-job/7/api/json",
+        expect.anything(),
+      )
+    })
+
+    it("tolerates a URL-style path that already contains /job/ separators", async () => {
+      vi.mocked(common.httpGetJson).mockResolvedValue(mockBuild)
+
+      await client.getBuild("folder/job/sub/job/my-job", 7)
+
+      expect(common.httpGetJson).toHaveBeenCalledWith(
+        "https://jenkins.example.com/job/folder/job/sub/job/my-job/7/api/json",
+        expect.anything(),
+      )
+    })
+
+    it("ignores a stray leading slash", async () => {
+      vi.mocked(common.httpGetJson).mockResolvedValue(mockBuild)
+
+      await client.getBuild("/folder/my-job", 7)
+
+      expect(common.httpGetJson).toHaveBeenCalledWith(
+        "https://jenkins.example.com/job/folder/job/my-job/7/api/json",
+        expect.anything(),
+      )
+    })
+
+    it("throws a clear INVALID_INPUT error when jobName is undefined", async () => {
+      await expect(
+        client.getBuild(undefined as unknown as string, 7),
+      ).rejects.toThrow(/jobName is required/)
+    })
+
+    it("throws a clear INVALID_INPUT error when jobName is empty", async () => {
+      await expect(client.listArtifacts("   ", 7)).rejects.toThrow(
+        /jobName is required/,
+      )
+    })
+  })
+
   describe("replayBuild", () => {
     it("should replay a build with no body when mainScript is omitted", async () => {
       const mockCrumb = {


### PR DESCRIPTION
## Problem

`jobPath()` in `src/lib/jenkins-client.ts` calls `name.split("/")` with no guard. This causes two failure modes that surface across every job/build/artifact tool:

1. **Cryptic crash on a missing `jobName`.** If a caller omits or mis-keys the argument, `name` is `undefined` and the tool fails with `Cannot read properties of undefined (reading 'split')` — which masks the real problem (the user thinks the server is broken for the *path* they passed, when in fact the argument never arrived).

2. **URL-style paths silently 404.** Pasting a nested job the way it appears in the Jenkins browser URL — `folder/job/my-job` — double-encodes the literal `job` separators into `folder/job/job/my-job` and returns 404. A stray leading slash (`/folder/my-job`) breaks it the same way.

## Fix

`jobPath` now:
- throws a clear `INVALID_INPUT` `McpError` when `jobName` is missing/empty, and
- filters empty and literal `job` segments, so plain nested names (`a/b`), URL-style paths (`a/job/b`), and stray leading slashes all resolve to the same Jenkins path.

## Tests

Adds 5 tests to `test/lib/jenkins-client.test.ts` covering nested-folder, URL-style, and leading-slash resolution plus both validation errors. Full suite green (`103 passed`), `tsc --noEmit` clean, `npm run build` clean.